### PR TITLE
Optimizer 2 to 3 stages

### DIFF
--- a/src/main/java/com/zygateley/compiler/Application.java
+++ b/src/main/java/com/zygateley/compiler/Application.java
@@ -44,7 +44,7 @@ public class Application {
 				*/
 		//PushbackReader sr = new PushbackReader(new StringReader("aj();"));
 		
-		String sourceFile = FileIO.getAbsolutePath("Examples/Example2.fnc");
+		String sourceFile = FileIO.getAbsolutePath("Examples/Example0.fnc");
 		PushbackReader pushbackReader = FileIO.getReader(sourceFile);
 		
 		String baseName = sourceFile.substring(0, sourceFile.lastIndexOf('.'));
@@ -76,10 +76,11 @@ public class Application {
 				Optimizer optimizer = new Optimizer(logFile);
 				Node optimizedTree = optimizer.optimize(syntaxTree, true);
 				
-				// Run backend into appropriate language
-				PythonTranslator tr = new PythonTranslator(optimizedTree, pythonFile);
-				//PythonTranslator tr = new PythonTranslator(syntaxTree, targetFile);
-				tr.toPython();
+				// Translate into Python
+				if (pythonFile != null) {
+					PythonTranslator translator = new PythonTranslator(optimizedTree, pythonFile);
+					translator.toPython();
+				}
 			}
 		
 			if (pythonFile != null) {

--- a/src/main/java/com/zygateley/compiler/Lexer.java
+++ b/src/main/java/com/zygateley/compiler/Lexer.java
@@ -273,7 +273,7 @@ public class Lexer {
 	private void createAddToken(String newToken, Terminal thisRule) throws IOException {
 		Symbol symbol = null;
 		String value = null;
-		if (thisRule == Terminal.VAR) {
+		if (thisRule == Terminal.VARIABLE) {
 			// Variable name
 			symbol = symbolTable.insert(newToken);
 		}

--- a/src/main/java/com/zygateley/compiler/Node.java
+++ b/src/main/java/com/zygateley/compiler/Node.java
@@ -192,6 +192,27 @@ public class Node implements Iterable<Node> {
 			return null;
 		}
 	}
+	/**
+	 * Return the position of the passed Node
+	 * within this Node's children.
+	 * If not found, it returns the 
+	 * index of this Node's last child +1
+	 * 
+	 * @param childNode node to find within this Node's children
+	 * @return index of this node in siblings or last position + 1 if not found
+	 */
+	public int indexOf(Node childNode) {
+		int runningIndex = 0;
+		Node childAt = this.firstChild;
+		while (childAt != null) {
+			if (childAt == childNode) {
+				return runningIndex;
+			}
+			childAt = childAt.rightSibling;
+			runningIndex++;
+		}
+		return runningIndex;
+	}
 	public void addChild(final Node newChild) {
 		if (newChild == null) return;
 		
@@ -208,6 +229,54 @@ public class Node implements Iterable<Node> {
 		}
 		
 		this.childCount++;
+	}
+	/**
+	 * Insert a child into this parent
+	 * at the position indicated. 
+	 * If a child exists at this index,
+	 * push the child at the position to the right.
+	 * If a child does not exist at this index,
+	 * add the child to the end of the child list.
+	 * 
+	 * @param index
+	 * @param newChild
+	 */
+	public void insertChild(int index, final Node newChild) {
+		if (newChild == null) return;
+		
+		Node currentChild = getChild(index);
+		if (currentChild != null) {
+			// Push children right and insert
+			
+			// Upwards
+			newChild.parent = this;
+			this.childCount++;
+			
+			// If at beginning of children
+			if (currentChild.leftSibling == null) {
+				// Downwards
+				this.firstChild = newChild;
+				
+				// Left
+				// (Nothing to do)
+			}
+			else {
+				// Downwards
+				// (Nothing to do)
+				
+				// Left
+				newChild.leftSibling = currentChild.leftSibling;
+				currentChild.leftSibling.rightSibling = newChild;
+			}
+
+			// Right
+			newChild.rightSibling = currentChild;
+			currentChild.leftSibling = newChild;
+		}
+		else {
+			// Append to end of list
+			this.addChild(newChild);
+		}
 	}
 	public void addRightSibling(final Node newSibling) {
 		if (newSibling == null) return;
@@ -272,17 +341,25 @@ public class Node implements Iterable<Node> {
 	public String toString(boolean withChildren) {
 		StringBuilder output = new StringBuilder();
 		Element element = Element.NULL;
-		if (this.terminal != null) {
-			// Terminal
-			output.append(terminal + "");
-			if (terminal.basicElement != Element.PASS) {
-				element = terminal.basicElement;
-			}
+		boolean isEmpty = true;
+		if (this.basicElement != null) {
+			element = this.basicElement;
 		}
-		else {
+		if (this.nonTerminal != null) {
 			// NonTerminal
 			output.append(nonTerminal + "");
 			element = nonTerminal.basicElement;
+			isEmpty = false;
+		}
+		if (this.terminal != null) {
+			// Terminal
+			if (isEmpty) {
+				output.append(terminal + "");
+				if (Element.NULL.equals(element) && terminal.basicElement != Element.PASS) {
+					element = terminal.basicElement;
+				}
+			}
+			else output.append(getParameterString("terminal", terminal + ""));
 		}
 		if (element != Element.NULL) {
 			output.append(getParameterString("element", element+""));

--- a/src/main/java/com/zygateley/compiler/Parser.java
+++ b/src/main/java/com/zygateley/compiler/Parser.java
@@ -747,8 +747,9 @@ public class Parser {
 	 * @param wrappingClass
 	 * @param splitToken token to label wrapping class with
 	 * @return Node the resulting subtree
+	 * @throws IOException 
 	 */
-	private Node mergeOperands(NonTerminal wrappingClass, Node leftOperand, Node rightOperand, Terminal splitToken) {
+	private Node mergeOperands(NonTerminal wrappingClass, Node leftOperand, Node rightOperand, Terminal splitToken) throws IOException {
 		// Do not combine fully empty
 		boolean leftIsNull = (leftOperand == null);
 		boolean rightIsNull = (rightOperand == null);
@@ -756,8 +757,6 @@ public class Parser {
 			return new Node(splitToken, null, null);
 		}
 		
-		// If both children have appropriate child nodes
-		// Create a new wrapper Node (NonTerminal.PrecedencePattern.nonTerminalWrapper)
 		Node wrapper = new Node(wrappingClass, splitToken);
 		wrapper.addChild(leftOperand);
 		wrapper.addChild(rightOperand);

--- a/src/main/java/com/zygateley/compiler/Token.java
+++ b/src/main/java/com/zygateley/compiler/Token.java
@@ -72,7 +72,7 @@ public interface Token {
 		// Statement FIRST set
 		ECHO = 			id.next(),
 		INPUT = 		id.next(),
-		VAR = 			id.next();
+		VARIABLE = 			id.next();
 	
 	// Operator set
 	public final static int firstOperator = id.id;
@@ -120,7 +120,7 @@ public interface Token {
 		_VALUEOREXPR_ = id.next(),
 		_EXPR_ = 		id.next(),
 		_VALUE_ = 		id.next(),
-		_VAR_ = 		id.next(),
+		_VARIABLE_ = 		id.next(),
 		_VAREXPR_ = 	id.next(),
 		_FUNCCALL_ = 	id.next(),
 		_ARGS0_ = 		id.next(),
@@ -180,12 +180,12 @@ public interface Token {
 		return array;
 	}
 	public static final int[] _STMT_FIRST = {
-			VAR,
+			VARIABLE,
 			INPUT,
 			ECHO,
 			COMMENT
 	};
-	public static final int[] _STMTS_FIRST = combineArrays(_STMT_FIRST, FUNCTION, IF, CURLY_OPEN, VAR, ECHO);
+	public static final int[] _STMTS_FIRST = combineArrays(_STMT_FIRST, FUNCTION, IF, CURLY_OPEN, VARIABLE, ECHO);
 
 	public final static int[] operatorSetRank1 = {
 			AND,
@@ -280,7 +280,7 @@ enum Terminal implements Token {
 	// Defined as <stmts> in CFG.xlsx
 	ECHO 		(Token.ECHO, Element.NULL, "echo"),
 	INPUT		(Token.INPUT, Element.NULL, "input"),
-	VAR			(Token.VAR, Symbol.Type.VAR, Element.VAROUT, "", ("^[a-zA-Z_][a-zA-Z\\d_]*")),
+	VARIABLE	(Token.VARIABLE, Symbol.Type.VAR, Element.VARIABLE, "", ("^[a-zA-Z_][a-zA-Z\\d_]*")),
 	// Any reserved words must be declared before VAR
 
 	// Defined as <ops> in CFG.xlsx
@@ -396,16 +396,16 @@ enum NonTerminal implements Token {
 				 follow(new int[] {Token.EOF, Token.CURLY_CLOSE})),
 	
 	_FUNCDEF_	(Token._FUNCDEF_, Element.FUNCDEF,
-				 firstTerminalsAndPattern(Token.FUNCTION, Token.FUNCTION, Token.VAR, Token.PAREN_OPEN, Token._PARAMS0_, Token.PAREN_CLOSE, Token._SCOPE_),
+				 firstTerminalsAndPattern(Token.FUNCTION, Token.FUNCTION, Token.VARIABLE, Token.PAREN_OPEN, Token._PARAMS0_, Token.PAREN_CLOSE, Token._SCOPE_),
 				 Token.commonFollow1),
 	
-	_PARAMS0_	(Token._PARAMS0_, Element.PARAM,
-				 firstTerminalsAndPattern(Token.VAR, Token.VAR, Token._PARAMS1_),
+	_PARAMS0_	(Token._PARAMS0_, Element.PARAMETERS,
+				 firstTerminalsAndPattern(Token.VARIABLE, Token.VARIABLE, Token._PARAMS1_),
 				 firstTerminalsAndPattern(Token.EMPTY, Token.EMPTY),
 				 follow(Token.PAREN_CLOSE)),
 	
 	_PARAMS1_	(Token._PARAMS1_, Element.PASS,
-				 firstTerminalsAndPattern(Token.COMMA, Token.COMMA, Token.VAR, Token._PARAMS1_),
+				 firstTerminalsAndPattern(Token.COMMA, Token.COMMA, Token.VARIABLE, Token._PARAMS1_),
 				 firstTerminalsAndPattern(Token.EMPTY, Token.EMPTY),
 				 follow(Token.PAREN_CLOSE)),
 	
@@ -440,7 +440,7 @@ enum NonTerminal implements Token {
 			 	 firstTerminalsAndPattern(Token.ECHO, Token._ECHO_, Token.SEMICOLON),
 			 	 firstTerminalsAndPattern(Token.INPUT, Token._INPUT_, Token.SEMICOLON),
 			 	 firstTerminalsAndPattern(Token.COMMENT, Token.COMMENT),
-				 firstTerminalsAndPattern(Token.VAR, Token.VAR, Token._VARSTMT_, Token.SEMICOLON),
+				 firstTerminalsAndPattern(Token.VARIABLE, Token.VARIABLE, Token._VARSTMT_, Token.SEMICOLON),
 				 Token.commonFollow2),
 	
 	_ECHO_		(Token._ECHO_, Element.OUTPUT,
@@ -448,7 +448,7 @@ enum NonTerminal implements Token {
 				 follow(Token.SEMICOLON)),
 	
 	_INPUT_		(Token._INPUT_, Element.INPUT,
-				 firstTerminalsAndPattern(Token.INPUT, Token.INPUT, Token.VAR),
+				 firstTerminalsAndPattern(Token.INPUT, Token.INPUT, Token.VARIABLE),
 				 follow(Token.SEMICOLON)),
 
 	_VARSTMT_	(Token._VARSTMT_, Element.PASS,
@@ -466,12 +466,12 @@ enum NonTerminal implements Token {
 	 			 follow(new int[] {Token.SEMICOLON, Token.PAREN_CLOSE, Token.COMMA})),
 	
 	_VALUE_		(Token._VALUE_, Element.PASS,
-				 firstTerminalsAndPattern(Token.VAR, Token._VAR_),
+				 firstTerminalsAndPattern(Token.VARIABLE, Token._VARIABLE_),
 				 firstTerminalsAndPattern(Token.primitiveSet, Token._LITERAL_),
 				 Token.commonFollow3),
 	
-	_VAR_		(Token._VAR_, Element.PASS,
-				 firstTerminalsAndPattern(Token.VAR, Token.VAR, Token._VAREXPR_),
+	_VARIABLE_	(Token._VARIABLE_, Element.PASS,
+				 firstTerminalsAndPattern(Token.VARIABLE, Token.VARIABLE, Token._VAREXPR_),
 				 Token.commonFollow3),
 	
 	_VAREXPR_	(Token._VAREXPR_, Element.PASS,
@@ -483,8 +483,8 @@ enum NonTerminal implements Token {
 				 firstTerminalsAndPattern(Token.PAREN_OPEN, Token.PAREN_OPEN, Token._ARGS0_, Token.PAREN_CLOSE),
 				 Token.commonFollow3),
 	
-	_ARGS0_		(Token._ARGS0_, Element.PASS,
-				 firstTerminalsAndPattern(Token.combineArrays(Token.combineArrays(Token.operatorSet, Token.VAR, Token.PLUS, Token.MINUS, Token.PAREN_OPEN), Token.primitiveSet), Token._EXPR_, Token._ARGS1_),
+	_ARGS0_		(Token._ARGS0_, Element.ARGUMENTS,
+				 firstTerminalsAndPattern(Token.combineArrays(Token.combineArrays(Token.operatorSet, Token.VARIABLE, Token.PLUS, Token.MINUS, Token.PAREN_OPEN), Token.primitiveSet), Token._EXPR_, Token._ARGS1_),
 				 firstTerminalsAndPattern(Token.EMPTY, Token.EMPTY),
 				 follow(Token.PAREN_CLOSE)),
 	


### PR DESCRIPTION
Broke down Optimizer from two stages to three. First, the translation is
made between parseNode and optimizationNode. Then the reflow binding
rules are applied. Finally, the excess nodes are removed. This allows
for a smoother application of a larger breadth of reflow rules. The
rules themselves were therefore cleaned up.

The MERGE rule was removed entirely. The back end expects elementary
language constructs, which is more node-driven than
node-property-driven. Keep nodes separate and apply elementary
constructs appropriately.